### PR TITLE
Deprecate this Repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
-# wh2o-docker
+# DEPRECATED
 
+This repository has been deprecated and is no longer in use. It is kept around for prosterity.
+
+See the durrent docker repo at: https://github.com/AmericanWhitewater/docker
+
+# wh2o-docker
 ### System Requirements
 
 - [`Docker Desktop - Mac`](https://www.docker.com/products/docker-desktop)


### PR DESCRIPTION
According to @ngottlieb, the repository is no longer in use. Let's update the README so that people don't accidently go down this rabbit hole in the future.

What this looks like in the README:
<img width="1145" alt="Screen Shot 2023-01-02 at 11 49 51 AM" src="https://user-images.githubusercontent.com/557689/210269485-6bcd5b3d-75bc-4391-804d-ce7ff96bc658.png">
